### PR TITLE
Bug fix: do not generate blank PDFs if save-only-completed is checked

### DIFF
--- a/MultiSignatureConsent.php
+++ b/MultiSignatureConsent.php
@@ -175,7 +175,7 @@ class MultiSignatureConsent extends \ExternalModules\AbstractExternalModule {
                 $statuses     = $formStatus[$record][$event_id] ?? [];
                 $anyComplete  = false;
                 foreach ($this->inputForms as $formName) {
-                    if (($statuses[$formName . '_complete'] ?? null) == '2') {
+                    if (($statuses[$formName . '_complete'] ?? null) === '2') {
                         $anyComplete = true;
                         break;
                     }

--- a/MultiSignatureConsent.php
+++ b/MultiSignatureConsent.php
@@ -166,6 +166,26 @@ class MultiSignatureConsent extends \ExternalModules\AbstractExternalModule {
 
             $this->emDebug("Logic True");
 
+            // If only saving completed forms, verify at least one is complete before generating
+            // a PDF. The redcap_pdf hook will then include only the completed forms' fields.
+            // Without this guard, the hook would return empty metadata and produce a blank PDF.
+            if (self::$SAVE_ONLY_COMPLETED) {
+                $statusFields = array_map(fn($f) => $f . '_complete', $this->inputForms);
+                $formStatus   = \REDCap::getData('array', $record, $statusFields, $event_id);
+                $statuses     = $formStatus[$record][$event_id] ?? [];
+                $anyComplete  = false;
+                foreach ($this->inputForms as $formName) {
+                    if (($statuses[$formName . '_complete'] ?? null) == '2') {
+                        $anyComplete = true;
+                        break;
+                    }
+                }
+                if (!$anyComplete) {
+                    $this->emDebug("Save Only Completed: no input forms are complete — skipping PDF generation");
+                    return false;
+                }
+            }
+
             // Make a PDF
             $this->emDebug("Making PDF", self::$MAKING_PDF);
             self::$MAKING_PDF = true;


### PR DESCRIPTION
If the "Save Only Completed Forms" option was checked, and the merge was triggered with none of the specified forms completed, a blank PDF would be generated.

New functionality is to not generate anything if this option is checked and no forms are marked as complete. If forms are marked as complete, they will be merged as expected.